### PR TITLE
Add Content-Type to `PyPIClient`

### DIFF
--- a/src/reporter/pypi_client.py
+++ b/src/reporter/pypi_client.py
@@ -24,7 +24,8 @@ class PyPIClient:
 
     def __init__(self) -> None:
         auth = BearerAuthentication(token=PyPI.api_token)
-        self.http_client = httpx.AsyncClient(auth=auth, base_url=PyPI.base_url)
+        headers = {"Content-Type": "application/vnd.pypi.api-v0-danger+json"}
+        self.http_client = httpx.AsyncClient(auth=auth, base_url=PyPI.base_url, headers=headers)
 
     async def echo(self) -> str:
         response = await self.http_client.get("/echo")


### PR DESCRIPTION
This is required by the API. Added as a hardcoded constant because we will likely need to modify other parts of the code to support new versions of the API anyway.

Closes #22 